### PR TITLE
Allow different templates for emails at different days

### DIFF
--- a/pmpro-extra-expiration-warning-emails.php
+++ b/pmpro-extra-expiration-warning-emails.php
@@ -3,7 +3,7 @@
 Plugin Name: PMPro Extra Expiration Warning Emails
 Plugin URI: http://www.paidmembershipspro.com/wp/pmpro-extra-expiration-warning-emails/
 Description: Send out more than one "membership expiration warning" email to users with PMPro.
-Version: .1
+Version: .2
 Author: Stranger Studios
 Author URI: http://www.strangerstudios.com
 */
@@ -27,15 +27,24 @@ function pmproeewe_extra_emails()
 	$today = date("Y-m-d 00:00:00");
 	
 	/*
-		Here is where you set how many emails you want to send and how early.
+		Here is where you set how many emails you want to send, how early, and which template files to e-mail.
+		If you set the template file to an empty string '' then it will send the default PMPro expiring e-mail.
+		Place your email templates in a subfolder of your active theme. Create a paid-memberships-pro folder in your theme folder,
+		and then create an email folder within that. Your template files should have a suffix of .html, but you don't put it below. So if you
+		create a file in there called myexpirationemail.html, then you'd just put 'myexpirationemail' in the array below.
+		(PMPro will fill in the .html for you.)
 	*/
-	$emails = array(30,60,90);		//<--- !!! UPDATE THIS LINE TO CHANGE WHEN EMAILS GO OUT !!! -->
-	sort($emails, SORT_NUMERIC);
+	$emails = array(
+		30	=> 'mem_expiring_30days',
+		60	=> 'mem_expiring_60days',
+		90	=>	'mem_expiring_90days'
+	);		//<--- !!! UPDATE THIS ARRAY TO CHANGE WHEN EMAILS GO OUT AND THEIR TEMPLATE FILES !!! -->
+	ksort($emails, SORT_NUMERIC);
 	
 	//array to store ids of folks we sent emails to so we don't email them twice
 	$sent_emails = array();
 	
-	foreach($emails as $days)
+	foreach(array_keys($emails) as $days)
 	{	
 		//look for memberships that are going to expire within one week (but we haven't emailed them within a week)
 		$sqlQuery = "SELECT mu.user_id, mu.membership_id, mu.startdate, mu.enddate FROM $wpdb->pmpro_memberships_users mu LEFT JOIN $wpdb->usermeta um ON um.user_id = mu.user_id AND um.meta_key = 'pmpro_expiration_notice_" . $days . "' WHERE mu.status = 'active' AND mu.enddate IS NOT NULL AND mu.enddate <> '' AND mu.enddate <> '0000-00-00 00:00:00' AND DATE_SUB(mu.enddate, INTERVAL " . $days . " Day) <= '" . $today . "' AND (um.meta_value IS NULL OR DATE_ADD(um.meta_value, INTERVAL " . $days . " Day) <= '" . $today . "') ORDER BY mu.enddate";
@@ -50,10 +59,24 @@ function pmproeewe_extra_emails()
 				$pmproemail = new PMProEmail();
 				$euser = get_userdata($e->user_id);		
 				$pmproemail->sendMembershipExpiringEmail($euser);
+				if($euser) {
+					$euser->membership_level = pmpro_getMembershipLevelForUser($euser->ID);
+						
+					$pmproemail->email = $euser->user_email;
+					$pmproemail->subject = sprintf(__("Your membership at %s will end soon", "pmpro"), get_option("blogname"));
+					if(strlen($emails[$days])>0) {
+						$pmproemail->template = $emails[$days];
+					} else {
+						$pmproemail->template = "membership_expiring";
+					}
+					$pmproemail->data = array("subject" => $pmproemail->subject, "name" => $euser->display_name, "user_login" => $euser->user_login, "sitename" => get_option("blogname"), "membership_id" => $euser->membership_level->id, "membership_level_name" => $euser->membership_level->name, "siteemail" => pmpro_getOption("from_email"), "login_link" => wp_login_url(), "enddate" => date(get_option('date_format'), $euser->membership_level->enddate), "display_name" => $euser->display_name, "user_email" => $euser->user_email);			
+			
+					$pmproemail->sendEmail();
 				
-				printf(__("Membership expiring email sent to %s. ", "pmpro"), $euser->user_email);
+					printf(__("Membership expiring email sent to %s. ", "pmpro"), $euser->user_email);
 				
-				$sent_emails[] = $e->user_id;
+					$sent_emails[] = $e->user_id;
+				}
 			}
 				
 			//update user meta so we don't email them again


### PR DESCRIPTION
Converted the days array into an associative array with the days as
keys. The values are file names of e-mail templates that are sent. This
way, people can have a different e-mail sent at 30 days out, 60 days
out, etc.