### PR TITLE
BUG: Includes any record containing a date in usermeta

### DIFF
--- a/pmpro-extra-expiration-warning-emails.php
+++ b/pmpro-extra-expiration-warning-emails.php
@@ -63,7 +63,10 @@ function pmproeewe_extra_emails()
 			  mu.startdate,
 			  mu.enddate
 			FROM {$wpdb->pmpro_memberships_users} AS mu
-			  LEFT JOIN {$wpdb->usermeta} AS um ON um.user_id = mu.user_id AND um.meta_key = %s
+			  LEFT JOIN {$wpdb->usermeta} AS um ON um.user_id = mu.user_id AND (
+	    			um.meta_key = %s AND
+	    			(um.meta_value IS NULL OR DATE_ADD(um.meta_value, INTERVAL %d DAY) <= %s)
+              		  )
 			  INNER JOIN {$wpdb->users} AS u ON u.ID = mu.user_id AND (
 			    mu.membership_id <> 0 OR
 			    mu.membership_id <> NULL
@@ -72,13 +75,10 @@ function pmproeewe_extra_emails()
 			      AND mu.enddate IS NOT NULL
 			      AND mu.enddate <> '0000-00-00 00:00:00'
 			      AND DATE_SUB(mu.enddate, INTERVAL %d DAY) <= %s
-			      AND (um.meta_key = %s AND
-			           (um.meta_value IS NULL OR DATE_ADD(um.meta_value, INTERVAL %d DAY) <= %s))
 			ORDER BY mu.enddate;",
 			"pmpro_expiration_notice_{$days}",
 			$days,
 			$today,
-			"pmpro_expiration_notice_{$days}",
 			$days,
 			$today
 		);

--- a/pmpro-extra-expiration-warning-emails.php
+++ b/pmpro-extra-expiration-warning-emails.php
@@ -57,26 +57,30 @@ function pmproeewe_extra_emails()
 	{	
 		//look for memberships that are going to expire within one week (but we haven't emailed them within a week)
 		$sqlQuery = $wpdb->prepare(
-			"SELECT mu.user_id, mu.membership_id, mu.startdate, mu.enddate
-		 	FROM {$wpdb->pmpro_memberships_users} AS mu
-         	 	LEFT JOIN {$wpdb->usermeta} AS um ON um.user_id = mu.user_id AND um.meta_key = %s
-				INNER JOIN {$wpdb->users} AS u ON u.ID = mu.user_id AND (
-					mu.membership_id <> 0 OR
-					mu.membership_id <> NULL OR
-					mu.membership_id <> 'NULL'
-				)
-		 	WHERE mu.status = 'active'
-      	 	 		AND mu.enddate IS NOT NULL
-				AND mu.enddate <> ''
-				AND mu.enddate <> '0000-00-00 00:00:00'
-			AND DATE_SUB(mu.enddate, INTERVAL %d Day) <= %s
-			AND (um.meta_value IS NULL OR DATE_ADD(um.meta_value, INTERVAL %d Day) <= %s)
-		 	ORDER BY mu.enddate",
-		 	"pmpro_expiration_notice_{$days}",
+			"SELECT
+			  mu.user_id,
+			  mu.membership_id,
+			  mu.startdate,
+			  mu.enddate
+			FROM {$wpdb->pmpro_memberships_users} AS mu
+			  LEFT JOIN {$wpdb->usermeta} AS um ON um.user_id = mu.user_id AND um.meta_key = %s
+			  INNER JOIN {$wpdb->users} AS u ON u.ID = mu.user_id AND (
+			    mu.membership_id <> 0 OR
+			    mu.membership_id <> NULL
+			  )
+			WHERE mu.status = 'active'
+			      AND mu.enddate IS NOT NULL
+			      AND mu.enddate <> '0000-00-00 00:00:00'
+			      AND DATE_SUB(mu.enddate, INTERVAL %d DAY) <= %s
+			      AND (um.meta_key = %s AND
+			           (um.meta_value IS NULL OR DATE_ADD(um.meta_value, INTERVAL %d DAY) <= %s))
+			ORDER BY mu.enddate;",
+			"pmpro_expiration_notice_{$days}",
 			$days,
-		 	$today,
+			$today,
+			"pmpro_expiration_notice_{$days}",
 			$days,
-		 	$today
+			$today
 		);
 
 		$expiring_soon = $wpdb->get_results($sqlQuery);


### PR DESCRIPTION
Could include records that were already processed by the Recurring Payment reminder add-on as well as this expiration plugin. SQL also runs w/o MySQL warnings.