### PR TITLE
BUG FIX: Would sometimes allow the run date/time to be incorrectly formatted

### DIFF
--- a/pmpro-extra-expiration-warning-emails.php
+++ b/pmpro-extra-expiration-warning-emails.php
@@ -18,28 +18,28 @@ add_action( "pmpro_cron_expiration_warnings", "pmproeewe_extra_emails", 30 );
  * Trigger execution of test version for the plugin.
  */
 function pmproeewe_test() {
-
+	
 	if ( isset( $_REQUEST['pmproeewe_test'] ) && intval( $_REQUEST['pmproeewe_test'] ) === 1 && current_user_can( 'manage_options' ) ) {
-
+		
 		// Force the system to _not_ send out emails
 		add_filter( 'pmproeewe_send_reminder_to_user', '__return_false', 999 );
-
+		
 		if ( WP_DEBUG ) {
 			error_log( "PMPROEEWE: Running expiration fuctionality" );
 		}
-
+		
 		pmproeewe_extra_emails();
-
+		
 		if ( WP_DEBUG ) {
 			error_log( "PMPROEEWE: Running the expiration functionality again (expecting no records found)" );
 		}
-
+		
 		pmproeewe_extra_emails();
-
+		
 		if ( WP_DEBUG ) {
 			error_log( "PMPROEEWE: Cleaning up after the test" );
 		}
-
+		
 		pmproeewe_cleanup_test();
 	}
 }
@@ -47,21 +47,21 @@ function pmproeewe_test() {
 add_action( 'init', 'pmproeewe_test' );
 
 function pmproeewe_cleanup_test() {
-
+	
 	global $wpdb;
-
+	
 	$emails = apply_filters( 'pmproeewe_email_frequency_and_templates', array(
 			30 => 'membership_expiring',
 			60 => 'membership_expiring',
-			90 => 'membership_expiring'
+			90 => 'membership_expiring',
 		)
 	);
-
+	
 	// Sort the received array in numeric order
 	ksort( $emails, SORT_NUMERIC );
-
+	
 	foreach ( $emails as $days => $template ) {
-
+		
 		$meta = "pmpro_expiration_test_notice_{$days}";
 		$wpdb->delete( $wpdb->usermeta, array( 'meta_key' => $meta ) );
 	}
@@ -74,21 +74,21 @@ function pmproeewe_cleanup_test() {
 */
 function pmproeewe_extra_emails() {
 	global $wpdb;
-
+	
 	$last = null;
-
-	// Allow test environment to determine the value of 'today'.
-	if ( ! isset( $_REQUEST['pmproeewe_test_date'] ) && current_user_can( 'manage_options' ) ) {
-
-		//default: make sure we only run once a day
-		$today = date_i18n( "Y-m-d 00:00:00", current_time( 'timestamp' ) );
-
-	} else {
+	
+	//Default: make sure we only run once per day
+	$today          = date_i18n( "Y-m-d 00:00:00", current_time( 'timestamp' ) );
+	$interval_start = $today;
+	
+	// Allow test environment to set the value of 'today'.
+	if ( isset( $_REQUEST['pmproeewe_test_date'] ) && current_user_can( 'manage_options' ) ) {
+		
 		// Test: Set the date based on received value
-		$test_date = sanitize_text_field( $_REQUEST['pmproeewe_test_date'] );
+		$test_date = isset( $_REQUEST['pmproeewe_test_date'] ) ? sanitize_text_field( $_REQUEST['pmproeewe_test_date'] ) : date( 'Y-m-d', current_time( 'timestamp' ) );
 		$today     = "{$test_date} 00:00:00";
 	}
-
+	
 	/*
 		Here is where you set how many emails you want to send, how early, and which template files to e-mail.
 		If you set the template file to an empty string '' then it will send the default PMPro expiring e-mail.
@@ -100,46 +100,52 @@ function pmproeewe_extra_emails() {
 	$emails = apply_filters( 'pmproeewe_email_frequency_and_templates', array(
 			30 => 'membership_expiring',
 			60 => 'membership_expiring',
-			90 => 'membership_expiring'
+			90 => 'membership_expiring',
 		)
 	);        //<--- !!! UPDATE THIS ARRAY TO CHANGE WHEN EMAILS GO OUT AND THEIR TEMPLATE FILES !!! -->
-
+	
 	ksort( $emails, SORT_NUMERIC );
-
+	
 	if ( WP_DEBUG && isset( $_REQUEST['pmproeewe_test'] ) && current_user_can( 'manage_options' ) ) {
 		error_log( "PMPROEEWE Template array: " . print_r( $emails, true ) );
 	}
-
+	
 	// add admin as Cc recipient?
 	$include_admin = apply_filters( 'pmproeewe_bcc_admin_user', false );
-
+	
 	if ( $include_admin ) {
 		add_filter( 'pmpro_email_headers', 'pmproeewe_add_admin_as_bcc' );
 	}
-
+	
 	//array to store ids of folks we sent emails to so we don't email them twice
 	$sent_emails = array();
-
-	foreach ( array_keys( $emails ) as $days ) {
-
+	
+	foreach ( $emails as $days => $email_template ) {
+		
 		$meta = "pmpro_expiration_notice_{$days}";
-
+		
 		// use a dummy meta value for tests
 		if ( isset( $_REQUEST['pmproeewe_test'] ) && intval( $_REQUEST['pmproeewe_test'] ) === 1 && current_user_can( 'manage_options' ) ) {
 			$meta = "pmpro_expiration_test_notice_{$days}";
 		}
-
-		// Configure the interval to select records from
-		if ( is_null( $last ) ) {
-
-			$interval_start = $today;
-		} else {
-
-			$interval_start = date_i18n( 'Y-m-d 00:00:00', strtotime( "{$today} +{$last} days", current_time( 'timestamp' ) ) );
+		
+		$start_ts = strtotime( "{$today} +{$last} days", current_time( 'timestamp' ) );
+		
+		// Have a valid start timestamp (skip if we're going through the loop for the 1st time)
+		if ( ! empty( $start_ts ) && ! is_null( $last ) ) {
+			
+			$interval_start = date_i18n( 'Y-m-d 00:00:00', $start_ts );
 		}
-
-		$interval_end = date_i18n( 'Y-m-d 00:00:00', strtotime( "{$today} +{$days} days", current_time( 'timestamp' ) ) );
-
+		
+		$interval_end_ts = strtotime( "{$today} +{$days} days", current_time( 'timestamp' ) );
+		
+		// Have an appropriate end timestamp?
+		if ( empty( $interval_end_ts ) ) {
+			continue;
+		}
+		
+		$interval_end = date_i18n( 'Y-m-d 00:00:00', $interval_end_ts );
+		
 		// Query returns records that fit between the pmproeewe_email_frequency_and_templates day values
 		// and only if they haven't had a warning notice sent already.
 		$sqlQuery = $wpdb->prepare(
@@ -165,33 +171,36 @@ function pmproeewe_extra_emails() {
 			$interval_start,
 			$interval_end
 		);
-
+		
 		if ( WP_DEBUG && isset( $_REQUEST['pmproeewe_test'] ) && current_user_can( 'manage_options' ) ) {
 			error_log( "PMPROEEWE SQL used: {$sqlQuery}" );
 		}
-
+		
 		$expiring_soon = $wpdb->get_results( $sqlQuery );
-
+		
 		if ( WP_DEBUG && isset( $_REQUEST['pmproeewe_test'] ) && current_user_can( 'manage_options' ) ) {
 			error_log( "PMPROEEWE: Found {$wpdb->num_rows} records to process for expiration warnings that are {$days} days out" );
 		}
-
+		
 		foreach ( $expiring_soon as $e ) {
-
+			
 			//send an email
 			$pmproemail = new PMProEmail();
 			$euser      = get_userdata( $e->user_id );
-
+			
 			if ( $euser ) {
 				$euser->membership_level = pmpro_getMembershipLevelForUser( $euser->ID );
-
+				
 				$pmproemail->email   = $euser->user_email;
 				$pmproemail->subject = sprintf( __( "Your membership at %s will end soon", "pmpro" ), get_option( "blogname" ) );
-				if ( strlen( $emails[ $days ] ) > 0 ) {
-					$pmproemail->template = $emails[ $days ];
+				
+				// The user specified a template name to use
+				if ( !empty( $email_template ) ) {
+					$pmproemail->template = $email_template;
 				} else {
 					$pmproemail->template = "membership_expiring";
 				}
+				
 				$pmproemail->data = array(
 					"subject"               => $pmproemail->subject,
 					"name"                  => $euser->display_name,
@@ -203,37 +212,38 @@ function pmproeewe_extra_emails() {
 					"login_link"            => wp_login_url(),
 					"enddate"               => date_i18n( get_option( 'date_format' ), $euser->membership_level->enddate ),
 					"display_name"          => $euser->display_name,
-					"user_email"            => $euser->user_email
+					"user_email"            => $euser->user_email,
 				);
-
+				
 				// Only actually send the message if we're not testing.
 				if ( true === apply_filters( 'pmproeewe_send_reminder_to_user', true ) ) {
 					$pmproemail->sendEmail();
 				} else {
-
+					
+					// Running a test exectution
 					$test_exp_days = round( ( ( $euser->membership_level->enddate - current_time( 'timestamp' ) ) / DAY_IN_SECONDS ), 0 );
-
+					
 					if ( WP_DEBUG && isset( $_REQUEST['pmproeewe_test'] ) && current_user_can( 'manage_options' ) ) {
 						error_log( "PMPROEEWE: Test mode and processing warnings for day {$days} (user's membership expires in {$test_exp_days} days): Faking email using template {$pmproemail->template} to {$euser->user_email} with parameters: " . print_r( $pmproemail->data, true ) );
 					}
 				}
-
+				
 				if ( WP_DEBUG ) {
-					error_log( sprintf( __( "Membership expiring email sent to %s. ", "pmpro" ), $euser->user_email ) );
+					error_log( sprintf("(Fake) Membership expiring email sent to %s. ", "pmpro" ), $euser->user_email );
 				}
-
+				
 				$sent_emails[] = $e->user_id;
-
+				
 				//delete any old user meta using this key just in case
 				delete_user_meta( $e->user_id, $meta );
 				
 				//update user meta to track that we sent notice
 				if ( false == update_user_meta( $e->user_id, $meta, $today ) ) {
-
-					if (WP_DEBUG) {
+					
+					if ( WP_DEBUG ) {
 						error_log( "Error: Unable to update {$meta} key for {$e->user_id}!" );
 					}
-
+					
 				} else {
 					if ( WP_DEBUG ) {
 						error_log( "Saved {$meta} = {$today} for {$e->user_id}: enddate = " . date_i18n( 'Y-m-d H:i:s', $euser->membership_level->enddate ) );
@@ -241,27 +251,27 @@ function pmproeewe_extra_emails() {
 				}
 			}
 		}
-
+		
 		// To track intervals
 		$last = $days;
 	}
-
+	
 	// remove the filter for admin
 	if ( $include_admin ) {
 		remove_filter( 'pmpro_email_headers', 'pmproeewe_add_admin_as_bcc' );
 	}
-
+	
 }
 
 /*
 Filter to add admin as Bcc for messages from this add-on
 */
 function pmproeewe_add_admin_as_bcc( $headers ) {
-
+	
 	$a_email   = get_option( 'admin_email' );
 	$admin     = get_user_by( 'email', $a_email );
 	$headers[] = "Bcc: {$admin->first_name} {$admin->last_name} <{$admin->user_email}>";
-
+	
 	return $headers;
 }
 
@@ -276,7 +286,7 @@ function pmproeewe_plugin_row_meta( $links, $file ) {
 		);
 		$links     = array_merge( $links, $new_links );
 	}
-
+	
 	return $links;
 }
 


### PR DESCRIPTION
Bad date/time value for the 'last run' metadata entry would result in daily messages for that message template/warning day.
Lined in separate patch

