### PR TITLE
Extend pmproeewe_send_reminder_to_user filter ability

### DIFF
--- a/pmpro-extra-expiration-warning-emails.php
+++ b/pmpro-extra-expiration-warning-emails.php
@@ -231,7 +231,7 @@ function pmproeewe_extra_emails() {
 				);
 				
 				// Only actually send the message if we're not testing.
-				if ( true === apply_filters( 'pmproeewe_send_reminder_to_user', true ) ) {
+				if ( true === apply_filters( 'pmproeewe_send_reminder_to_user', true, $euser ) ) {
 					$pmproemail->sendEmail();
 				} else {
 					


### PR DESCRIPTION
Extends filter similar to this plugin:
https://github.com/strangerstudios/pmpro-recurring-emails/blob/c332b5fe5d27d7aefd36af779f112dfa690317f6/pmpro-recurring-emails.php#L244

Use Case: 
Would allow for canceling the reminder email sending to specific levels like so:

function dont_send_to_level( $send_mail, $user ) {

	$level_to_skip = 1;
	
	if( $user->membership_level->id === $level_to_skip ) {
		// Don't send the email
		$send_mail = false;
	}
	
	return $send_mail;
}
add_filter( 'pmproeewe_send_reminder_to_user', 'dont_send_to_level', 10, 2 );