### PR TITLE
Feature/action scheduler support

### DIFF
--- a/pmpro-extra-expiration-warning-emails.php
+++ b/pmpro-extra-expiration-warning-emails.php
@@ -55,11 +55,7 @@ function pmproeewe_extra_emails() {
 
 	// New in v3.5: Unhook the PMPro_Scheduled_Actions class expiration reminder function.
 	if ( class_exists( 'PMPro_Scheduled_Actions' ) ) {
-		remove_action(
-			'pmpro_schedule_daily',
-			array( PMPro_Scheduled_Actions::instance(), 'membership_expiration_reminders' ),
-			99
-		);
+		remove_action( 'pmpro_schedule_daily', array( PMPro_Scheduled_Actions::instance(), 'pmpro_expire_memberships' ), 10 );
 	} else {
 		// Fallback for older versions of PMPro.
 		remove_action( 'pmpro_cron_expiration_warnings', 'pmpro_cron_expiration_warnings' );

--- a/pmpro-extra-expiration-warning-emails.php
+++ b/pmpro-extra-expiration-warning-emails.php
@@ -3,7 +3,7 @@
 Plugin Name: Paid Memberships Pro - Extra Expiration Warning Emails Add On
 Plugin URI: https://www.paidmembershipspro.com/add-ons/extra-expiration-warning-emails-add-on/
 Description: Send out more than one "membership expiration warning" email to users with PMPro.
-Version: 1.0
+Version: 1.0.1
 Author: Paid Memberships Pro
 Author URI: https://www.paidmembershipspro.com
 Text Domain: pmpro-extra-expiration-warning-emails
@@ -53,13 +53,22 @@ add_action( 'init', 'pmproeewe_test' );
 function pmproeewe_extra_emails() {
 	global $wpdb;
 
-	// Unhook the core expiration warning email function.
-	remove_action( 'pmpro_cron_expiration_warnings', 'pmpro_cron_expiration_warnings' );
-
-	// Clean up errors in the memberships_users table that could cause problems.
-	if( function_exists( 'pmpro_cleanup_memberships_users_table' ) ) {
-		pmpro_cleanup_memberships_users_table();
+	// New in v3.5: Unhook the PMPro_Scheduled_Actions class expiration reminder function.
+	if ( class_exists( 'PMPro_Scheduled_Actions' ) ) {
+		remove_action(
+			'pmpro_schedule_daily',
+			array( PMPro_Scheduled_Actions::instance(), 'membership_expiration_reminders' ),
+			99
+		);
+	} else {
+		// Fallback for older versions of PMPro.
+		remove_action( 'pmpro_cron_expiration_warnings', 'pmpro_cron_expiration_warnings' );
+		// Clean up errors in the memberships_users table that could cause problems.
+		if( function_exists( 'pmpro_cleanup_memberships_users_table' ) ) {
+			pmpro_cleanup_memberships_users_table();
+		}
 	}
+
 	
 	/**
 	 * DO NOT edit this add-on!
@@ -219,7 +228,13 @@ function pmproeewe_extra_emails() {
 		pmproeewe_output_log();
 	}
 }
-add_action( 'pmpro_cron_expiration_warnings', 'pmproeewe_extra_emails', 5 );
+// New in v3.5: Hook the PMPro_Scheduled_Actions class daily action.
+if ( class_exists( 'PMPro_Scheduled_Actions' ) ) {
+	add_action( 'pmpro_schedule_daily', 'pmproeewe_extra_emails', 99 );
+} else {
+	// Fallback for older versions of PMPro.
+	add_action( 'pmpro_cron_expiration_warnings', 'pmproeewe_extra_emails', 5 );
+}
 
 /**
  * Helper function to determine whether a test is being run.


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-lock-membership-level/blob/dev/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-lock-membership-level/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Paid Memberships Pro is moving to Action Scheduler to handle all of its queue-based and batch processing needs (cron jobs, long-running scripts, imports, exports).

Changes are needed in Add Ons that utilized or modify the previous `wp-cron`-based architecture.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds conditional support for newer versions of Paid Memberships Pro that offer Action Scheduler queuing.

### How to test the changes in this Pull Request:

1. [Install the Action Scheduler-based version of PMPro](https://github.com/strangerstudios/paid-memberships-pro/pull/3393) (likely version 3.5 or higher) 
2. Using WP-Crontrol or similar, observe that all the cron schedules have been removed. Test Membership expiry emails, and see that _Extra Expiration Warning Emails_ now hooks to `pmpro_schedule_daily`, a daily helper hook that leverage Action Scheduler.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
