### PR TITLE
Adding !!renew_url!! and using core membesrhip_expiring email logic when possible

### DIFF
--- a/pmpro-extra-expiration-warning-emails.php
+++ b/pmpro-extra-expiration-warning-emails.php
@@ -176,14 +176,7 @@ function pmproeewe_extra_emails() {
 							$pmproemail = new PMProEmail();
 							$pmproemail->email   = $euser->user_email;
 							$pmproemail->subject = sprintf( __( 'Your membership at %s will end soon', 'pmpro-extra-expiration-warning-emails' ), get_option( 'blogname' ) );
-							
-							// The user specified a template name to use
-							if ( ! empty( $email_template ) ) {
-								$pmproemail->template = $email_template;
-							} else {
-								$pmproemail->template = "membership_expiring";
-							}
-							
+							$pmproemail->template = $email_template;
 							$pmproemail->data = array(
 								"subject"               => $pmproemail->subject,
 								"name"                  => $euser->display_name,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-extra-expiration-warning-emails/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-extra-expiration-warning-emails/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Currently when this Add On is active, the `!!renew_url!!` email template variable would not populate in the Membership Expiring emails even though that variable is present in core PMPro.

This PR fixes that issue by adding the `!!renew_url!! email template variable to all email templates sent by this Add On, but also shifts to allow core to send the email when the `membership_expiring` template is being sent to help future-proof this plugin and avoid these kinds of issues in the future.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
