### PR TITLE
prevent membership_id conflicts in multisite

### DIFF
--- a/pmpro-extra-expiration-warning-emails.php
+++ b/pmpro-extra-expiration-warning-emails.php
@@ -218,6 +218,12 @@ function pmproeewe_extra_emails() {
                 } else {
                     pmproeewe_log( "Saved {$full_meta} = {$today} for {$e->user_id}: enddate = " . date_i18n( 'Y-m-d H:i:s', $euser->membership_level->enddate ) );
                 }
+
+                if ( $meta !== $site_meta ) {
+                    // Remove the non-multisite meta key for backward compatibility.
+                    $full_meta_compat = $meta . $e->membership_id;
+                    delete_user_meta( $e->user_id, $full_meta_compat ); // Remove old key.
+                }
 			}
 		}
 		

--- a/pmpro-extra-expiration-warning-emails.php
+++ b/pmpro-extra-expiration-warning-emails.php
@@ -112,6 +112,13 @@ function pmproeewe_extra_emails() {
 	// Use a dummy meta value for tests.
 	$meta = pmproeewe_is_test() ? 'pmproewee_expiration_test_notice_' : 'pmproewee_expiration_notice_';
 
+    // If multisite, we need to adjust the meta key to avoid conflicts.
+    if ( is_multisite() ) {
+        $site_meta =  $meta . get_current_blog_id() . '_';
+    } else {
+        $site_meta = $meta;
+    }
+
 	// Get the current date/time.
 	$today = date_i18n( "Y-m-d H:i:s", current_time( 'timestamp' ) );
 	// Allow test environment to set the value of 'today'.
@@ -129,22 +136,26 @@ function pmproeewe_extra_emails() {
 		// Query returns records that fit between the pmproeewe_email_frequency_and_templates day values
 		// and only if they haven't had a warning notice sent already.
 		$sqlQuery = $wpdb->prepare(
-			"SELECT DISTINCT
+			"SELECT
   				mu.user_id,
   				mu.membership_id,
   				mu.startdate,
  				mu.enddate,
- 				um.meta_value AS notice 			  
+ 				MAX(um.meta_value) AS notice 			  
  			FROM {$wpdb->pmpro_memberships_users} AS mu
- 			  LEFT JOIN {$wpdb->usermeta} AS um ON ( um.user_id = mu.user_id ) AND ( um.meta_key = CONCAT( %s, mu.membership_id ) )
+ 			  LEFT JOIN {$wpdb->usermeta} AS um 
+              ON ( um.user_id = mu.user_id )
+              AND ( um.meta_key = CONCAT( %s, mu.membership_id ) OR um.meta_key = CONCAT( %s, mu.membership_id ) )
 			WHERE ( um.meta_value IS NULL OR DATE_ADD(um.meta_value, INTERVAL %d DAY) < mu.enddate )  
 				AND ( mu.status = 'active' )
 				AND ( mu.enddate IS NOT NULL )
  				AND ( mu.enddate <> '0000-00-00 00:00:00' )
  				AND ( mu.enddate BETWEEN %s AND %s )
  				AND ( mu.membership_id <> 0 OR mu.membership_id <> NULL )
+            GROUP BY mu.user_id, mu.membership_id, mu.startdate, mu.enddate
 			ORDER BY mu.enddate",
 			$meta,
+            $site_meta,
 			$days,
 			date_i18n( 'Y-m-d H:i:s', strtotime( "{$today} +{$last} days", current_time( 'timestamp' ) ) ), // Start date to being looking for expiring memberhsips.
 			date_i18n( 'Y-m-d H:i:s', strtotime( "{$today} +{$days} days", current_time( 'timestamp' ) ) ) // End date to stop looking for expiring memberships.
@@ -200,13 +211,13 @@ function pmproeewe_extra_emails() {
 					pmproeewe_log( sprintf("Membership expiring email sent to user ID %d. ",  $e->user_id ) );
 				}
 
-				// Update user meta to track that we sent notice.
-				$full_meta = $meta . $e->membership_id;
-				if ( false == update_user_meta( $e->user_id, $full_meta, $today ) ) {
-					pmproeewe_log( "Error: Unable to update {$full_meta} key for {$e->user_id}!" );
-				} else {
-					pmproeewe_log( "Saved {$full_meta} = {$today} for {$e->user_id}: enddate = " . date_i18n( 'Y-m-d H:i:s', $euser->membership_level->enddate ) );
-				}
+                // Update user meta to track that we sent notice.
+                $full_meta = $site_meta . $e->membership_id;
+                if ( false == update_user_meta( $e->user_id, $full_meta, $today ) ) {
+                    pmproeewe_log( "Error: Unable to update {$full_meta} key for {$e->user_id}!" );
+                } else {
+                    pmproeewe_log( "Saved {$full_meta} = {$today} for {$e->user_id}: enddate = " . date_i18n( 'Y-m-d H:i:s', $euser->membership_level->enddate ) );
+                }
 			}
 		}
 		


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-extra-expiration-warning-emails/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-extra-expiration-warning-emails/pulls/) for the same update/change?

### Changes proposed in this Pull Request:
Update user meta_key to include site id in a multisite environment.
Refine sql query to take max enddate (to permit old meta_key style and meta_key style)

Resolves #39 .

### How to test the changes in this Pull Request:

1. Create membership levels on subsite 1 and subsite 2.  Have one expire on 12/15/2026 and one expire on 1/1/2026.
2. Let daily job run to send notices (with 30 day notice period).
3. BOTH sites should trigger a notice.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?


### Changelog entry

BUG FIX:  Fixed issue in multisite environments where membership_id's can be the same for different memberships across sites.
