### PR TITLE
Allow admin email to be a non-user

### DIFF
--- a/pmpro-extra-expiration-warning-emails.php
+++ b/pmpro-extra-expiration-warning-emails.php
@@ -283,9 +283,15 @@ add_action( 'init', 'pmproeewe_check_for_upgrades', 99 );
  * @since 1.0
  */
 function pmproeewe_add_admin_as_bcc( $headers ) {
-	$a_email   = get_option( 'admin_email' );
-	$admin     = get_user_by( 'email', $a_email );
-	$headers[] = "Bcc: {$admin->first_name} {$admin->last_name} <{$admin->user_email}>";
+	$a_email = get_option( 'admin_email' );
+	$admin   = get_user_by( 'email', $a_email );
+
+    // Handle cases with the admin_email is not associated with a user.
+    if ( $admin && isset( $admin->first_name, $admin->last_name, $admin->user_email ) ) {
+		$headers[] = "Bcc: {$admin->first_name} {$admin->last_name} <{$admin->user_email}>";
+	} elseif ( $a_email && is_email( $a_email ) ) {
+		$headers[] = "Bcc: {$a_email}";
+	}
 	
 	return $headers;
 }

--- a/pmpro-extra-expiration-warning-emails.php
+++ b/pmpro-extra-expiration-warning-emails.php
@@ -286,9 +286,14 @@ function pmproeewe_add_admin_as_bcc( $headers ) {
 	$a_email = get_option( 'admin_email' );
 	$admin   = get_user_by( 'email', $a_email );
 
-    // Handle cases with the admin_email is not associated with a user.
-    if ( $admin && isset( $admin->first_name, $admin->last_name, $admin->user_email ) ) {
-		$headers[] = "Bcc: {$admin->first_name} {$admin->last_name} <{$admin->user_email}>";
+	// Handle cases where the admin_email is not associated with a user, or the user has no name on file.
+	if ( $admin && is_email( $admin->user_email ) ) {
+		$name = trim( $admin->first_name . ' ' . $admin->last_name );
+		if ( '' !== $name ) {
+			$headers[] = "Bcc: {$name} <{$admin->user_email}>";
+		} else {
+			$headers[] = "Bcc: {$admin->user_email}";
+		}
 	} elseif ( $a_email && is_email( $a_email ) ) {
 		$headers[] = "Bcc: {$a_email}";
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-extra-expiration-warning-emails/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-extra-expiration-warning-emails/pulls/) for the same update/change?


### Changes proposed in this Pull Request:
Add checking to email and related user (if any) before adding to email headers.

Resolves #37 .

### How to test the changes in this Pull Request:

1. Change site admin email to an address not associated with a current user.
2. Let pmproeewe send out expiration emails.
3. Confirm email is sent to user and admin email.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry
BUG FIX:  BCC'ing the admin email would fail if admin email is not associated with a site user.