### PR TITLE
Scope expiration-notice tracking per-site via update_user_option

### DIFF
--- a/pmpro-extra-expiration-warning-emails.php
+++ b/pmpro-extra-expiration-warning-emails.php
@@ -35,8 +35,12 @@ function pmproeewe_test() {
 		pmproeewe_extra_emails();
 		pmproeewe_log( "TEST: Cleaning up after the test" );
 		
-		// Clean up after the test.
-		$wpdb->query( "DELETE FROM {$wpdb->usermeta} WHERE meta_key LIKE 'pmproewee_expiration_test_notice_%'" );
+		// Clean up after the test. Matches both the legacy (unscoped) and blog-prefixed shapes.
+		$wpdb->query( $wpdb->prepare(
+			"DELETE FROM {$wpdb->usermeta} WHERE meta_key LIKE %s OR meta_key LIKE %s",
+			'pmproewee_expiration_test_notice_%',
+			$wpdb->get_blog_prefix() . 'pmproewee_expiration_test_notice_%'
+		) );
 
 		// Output the log.
 		pmproeewe_output_log();
@@ -144,7 +148,7 @@ function pmproeewe_extra_emails() {
  				AND ( mu.enddate BETWEEN %s AND %s )
  				AND ( mu.membership_id <> 0 OR mu.membership_id <> NULL )
 			ORDER BY mu.enddate",
-			$meta,
+			$wpdb->get_blog_prefix() . $meta,
 			$days,
 			date_i18n( 'Y-m-d H:i:s', strtotime( "{$today} +{$last} days", current_time( 'timestamp' ) ) ), // Start date to being looking for expiring memberhsips.
 			date_i18n( 'Y-m-d H:i:s', strtotime( "{$today} +{$days} days", current_time( 'timestamp' ) ) ) // End date to stop looking for expiring memberships.
@@ -162,6 +166,20 @@ function pmproeewe_extra_emails() {
 			// Make sure that we have a user.
 			$euser = get_userdata( $e->user_id );
 			if ( ! empty( $euser ) ) {
+				// Migrate any legacy (pre-per-site) notice timestamp written by older versions of
+				// this add-on into the per-site key, then drop the legacy row. If the legacy
+				// notice was sent within the current $days window of enddate, skip the send to
+				// avoid double-notifying during the transition.
+				$legacy_notice = get_user_meta( $e->user_id, $meta . $e->membership_id, true );
+				if ( ! empty( $legacy_notice ) ) {
+					update_user_option( $e->user_id, $meta . $e->membership_id, $legacy_notice );
+					delete_user_meta( $e->user_id, $meta . $e->membership_id );
+					if ( strtotime( $legacy_notice ) + ( $days * DAY_IN_SECONDS ) >= strtotime( $e->enddate ) ) {
+						pmproeewe_log( "Skipped user ID {$e->user_id} membership {$e->membership_id}: legacy notice {$legacy_notice} is within {$days} days of enddate {$e->enddate}." );
+						continue;
+					}
+				}
+
 				$euser->membership_level = pmpro_getSpecificMembershipLevelForUser( $euser->ID, $e->membership_id );
 				
 				// Only actually send the message if we're not testing.
@@ -200,9 +218,12 @@ function pmproeewe_extra_emails() {
 					pmproeewe_log( sprintf("Membership expiring email sent to user ID %d. ",  $e->user_id ) );
 				}
 
-				// Update user meta to track that we sent notice.
+				// Track that we sent the notice. update_user_option (not update_user_meta) scopes
+				// the meta_key to $wpdb->get_blog_prefix(), so on a multisite where each subsite
+				// runs its own PMPro install the notice-sent state from one subsite does not
+				// clobber another.
 				$full_meta = $meta . $e->membership_id;
-				if ( false == update_user_meta( $e->user_id, $full_meta, $today ) ) {
+				if ( false == update_user_option( $e->user_id, $full_meta, $today ) ) {
 					pmproeewe_log( "Error: Unable to update {$full_meta} key for {$e->user_id}!" );
 				} else {
 					pmproeewe_log( "Saved {$full_meta} = {$today} for {$e->user_id}: enddate = " . date_i18n( 'Y-m-d H:i:s', $euser->membership_level->enddate ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-extra-expiration-warning-emails/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-extra-expiration-warning-emails/pulls/) for the same update/change?

### Changes proposed in this Pull Request:

Alternative fix for the multisite expiration-notice collision described in #39 (and addressed by #40).

Instead of inventing a `<blog_id>_` prefix scheme inside the meta_key string, this uses WordPress's native `update_user_option()` / `get_user_option()`. Those functions automatically prefix the meta_key with `$wpdb->get_blog_prefix()`, which is the canonical way WP scopes user data per-site (the same mechanism core uses for capabilities, dashboard prefs, etc.). No `is_multisite()` branching, no hand-rolled blog_id suffix.

The SQL is left structurally intact — the only change is passing `$wpdb->get_blog_prefix() . $meta` as the prepared placeholder. Single-site behavior is unaffected: the blog prefix is just `wp_` and the new key shape is consistent.

To migrate existing installs without double-notifying during the transition, the loop now reads any legacy (pre-per-site) timestamp once per row, adopts it into the new per-site key, deletes the legacy row, and skips the send if the legacy notice was sent within the current `$days` window of enddate. Adopting the legacy value into the per-site key (rather than just deleting) preserves the per-iteration `WHERE`-clause semantics across the 30/60/90-day windows — a user whose `enddate` falls exactly on a window boundary is still filtered correctly by the SQL in the next iteration.

Test cleanup is updated to match both the legacy and blog-prefixed shapes.

This closes #40 as an alternative implementation. See related core discussion: strangerstudios/paid-memberships-pro#3683.

### How to test the changes in this Pull Request:

1. On a multisite install with two subsites, each running its own PMPro instance, give the same user a membership at the same `membership_id` on each subsite, with different expiration dates close enough for the daily reminder window to apply.
2. Run the daily cron on subsite A. Confirm the notice is sent and `wp_<A>_pmproewee_expiration_notice_<membership_id>` is written for that user.
3. Run the daily cron on subsite B. Confirm subsite B independently evaluates and sends its own notice (does not get suppressed by subsite A's state), and that `wp_<B>_pmproewee_expiration_notice_<membership_id>` is written.
4. On a single-site install with an existing `pmproewee_expiration_notice_<membership_id>` row from a prior plugin version, run the daily cron and confirm: (a) the legacy row is removed, (b) the new `wp_pmproewee_expiration_notice_<membership_id>` row is created with the legacy value or today's date as appropriate, (c) no duplicate notice is sent if the legacy was within the current `$days` window.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

BUG FIX: Fixed issue in multisite environments where membership_id's can be the same for different memberships across sites. The notice-sent timestamp is now stored per-site via WordPress's `update_user_option()`, and any legacy (unscoped) timestamps are migrated into the per-site key on the next cron run.
